### PR TITLE
Expose advertised_route_priority

### DIFF
--- a/ha-vpn/README.md
+++ b/ha-vpn/README.md
@@ -33,7 +33,7 @@ module "ha-vpn" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
-| advertised\_route\_priority | The priority of routes advertised to the BGP peers | `number` | `100` | no |
+| advertised\_route\_priority | The priority of routes advertised to the BGP peers | `list(number)` | `0,0` | no |
 | bgp\_asn | ASN of the Cloud Router | `number` | n/a | yes |
 | bgp\_cr\_session\_range | Source IP and range of cloud router BGP session. A valid /30 subnet like 169.254.0.5/30 | `list` | n/a | yes |
 | cloud\_router\_name | n/a | `string` | n/a | yes |

--- a/ha-vpn/main.tf
+++ b/ha-vpn/main.tf
@@ -72,19 +72,21 @@ resource "google_compute_router_interface" "vpn-rtr-interface1" {
 }
 
 resource "google_compute_router_peer" "vpn-rtr-peer0" {
-  provider        = google-beta
-  name            = "${var.resource_prefix}-peer0"
-  router          = google_compute_router.vpn-rtr.name
-  peer_ip_address = var.peer_remote_session_range[0]
-  peer_asn        = var.peer_asn
-  interface       = google_compute_router_interface.vpn-rtr-interface0.name
+  provider                  = google-beta
+  name                      = "${var.resource_prefix}-peer0"
+  router                    = google_compute_router.vpn-rtr.name
+  peer_ip_address           = var.peer_remote_session_range[0]
+  peer_asn                  = var.peer_asn
+  advertised_route_priority = var.advertised_route_priority[0]
+  interface                 = google_compute_router_interface.vpn-rtr-interface0.name
 }
 
 resource "google_compute_router_peer" "vpn-rtr-peer1" {
-  provider        = google-beta
-  name            = "${var.resource_prefix}-peer1"
-  router          = google_compute_router.vpn-rtr.name
-  peer_ip_address = var.peer_remote_session_range[1]
-  peer_asn        = var.peer_asn
-  interface       = google_compute_router_interface.vpn-rtr-interface1.name
+  provider                  = google-beta
+  name                      = "${var.resource_prefix}-peer1"
+  router                    = google_compute_router.vpn-rtr.name
+  peer_ip_address           = var.peer_remote_session_range[1]
+  peer_asn                  = var.peer_asn
+  advertised_route_priority = var.advertised_route_priority[1]
+  interface                 = google_compute_router_interface.vpn-rtr-interface1.name
 }

--- a/ha-vpn/variables.tf
+++ b/ha-vpn/variables.tf
@@ -1,49 +1,49 @@
 
 variable "network" {
-  type = string
+  type        = string
   description = "The name of the network to use"
 }
 
 variable "region" {
-  type = string
-  description ="The region where the gateway and tunnels are going to be created"
+  type        = string
+  description = "The region where the gateway and tunnels are going to be created"
 }
 
 
 variable "bgp_asn" {
-  type = number
+  type        = number
   description = "ASN of the Cloud Router"
 }
 
 variable "peer_asn" {
-  type = number
+  type        = number
   description = "ASN of the peer VPN's router"
 }
 
 variable "peer_ips" {
-  type = list
+  type        = list
   description = "Peer Tunnel IPs"
 }
 
 variable "gateway_name" {
-  type = string
+  type        = string
   description = "The name of the VPN gateway being created"
 }
 
 
 variable "advertised_route_priority" {
-  type = number
-  default = 100
+  type        = list(number)
   description = "The priority of routes advertised to the BGP peers"
+  default     = [0, 0]
 }
 
 variable "bgp_cr_session_range" {
-  type = list
+  type        = list
   description = "Source IP and range of cloud router BGP session. A valid /30 subnet like 169.254.0.5/30"
 }
 
 variable "peer_remote_session_range" {
-  type = list
+  type        = list
   description = "Remote peer IP of cloud router BGP session. A valid ip in a /30 block like 169.254.0.6"
 }
 
@@ -52,11 +52,11 @@ variable "cloud_router_name" {
 }
 
 variable "resource_prefix" {
-  type = string
+  type        = string
   description = "Resource Prefix for the GCP Resources, allow multiple instanstiation of this module"
 }
 
 variable "shared_secrets" {
-  type = list
+  type        = list
   description = "IKEv2 Secret of the Tunnels"
 }


### PR DESCRIPTION
When creating HA VPS with Rackspace's Cisco ASA's we need to provide the advertised route priority. 

Exposes: `advertised_route_priority` with a default list(number) [0, 0] active/active but allows customization when required.


