### PR TITLE
Modules moved and deprecated notice

### DIFF
--- a/partner-interconnect/README.md
+++ b/partner-interconnect/README.md
@@ -1,43 +1,6 @@
-# gcp-partner-interconnect
-
-This module creates a Partner Interconnect.
-
-## Basic Usage
-
-```
-module "partner-interconnect" {
-source = ../path/to//module
-
-  vlans             = ["vlan-a", "vlan-b"]
-  asn               = "16550"
-  advertise_mode    = "CUSTOM"
-  advertised_groups = ["ALL_SUBNETS"]
-
-  network           = "<NETWORK>"
-}
-```
+## gcp-partner-interconnect
 
 
-## Providers
+# ** This module is now DEPRECATED and has moved **
 
-| Name | Version |
-|------|---------|
-| google | n/a |
-
-## Inputs
-
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
-| advertise\_mode | Mode to use for advertisement. Valid values of this enum field are: DEFAULT, CUSTOM | `string` | `"DEFAULT"` | no |
-| asn | Local BGP Autonomous System Number (ASN). Must be an RFC6996 private ASN | `string` | `"16550"` | no |
-| network | The VPC network on which this router lives | `string` | n/a | yes |
-| vlans | The list of vlan attachments being created | `list(string)` | n/a | yes |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| bgp\_config | Cloud router BGP config |
-| cloud\_router\_name | Cloud router name |
-| interconnect\_pairing\_key | The identifier of a PARTNER attachment used to initiate provisioning with selected partner |
-| interconnect\_vlan\_name | The VLAN attachment name |
+New location: https://github.com/global-build/terraform-google-partner_interconnect

--- a/rs-base-firewall/README.md
+++ b/rs-base-firewall/README.md
@@ -1,30 +1,6 @@
-# rs-base-firewall
+## rs-base-firewall
 
-This module creates the Rackspace Firewall rules to allow ingress from Rackspace Bastions
 
-```
-module "rs_firewall" {
- source = "git@github.com:racker/mgcp-terraform-modules//rs-base-firewall/?ref=master"
+# ** This module is now DEPRECATED and has moved **
 
- network_name = "network"
-
-}
-```
-
-## Providers
-
-| Name | Version |
-|------|---------|
-| google | n/a |
-
-## Inputs
-
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
-| network\_name | n/a | `string` | n/a | yes |
-| rax\_ranges | n/a | `list` | <pre>[<br>  "134.213.179.10",<br>  "172.99.99.10",<br>  "161.47.0.10",<br>  "146.20.2.10",<br>  "134.213.178.10",<br>  "119.9.122.10",<br>  "119.9.148.10",<br>  "72.3.186.100",<br>  "134.213.183.100",<br>  "146.20.30.100",<br>  "161.47.6.100",<br>  "134.213.182.100",<br>  "120.136.39.100",<br>  "119.9.163.100"<br>]<br></pre> | no |
-| rule\_prefix | n/a | `string` | `""` | no |
-
-## Outputs
-
-No output.
+New location: https://github.com/global-build/terraform-google-rs_base_firewall

--- a/rs-sd-policy/README.md
+++ b/rs-sd-policy/README.md
@@ -1,65 +1,6 @@
-# rs-sd-policy
+## rs-sd-policy
 
-This module creates the Rackspace Stackdriver Monitoring policies
 
-```
-module "rs_sd_policy" {
- source = "git@github.com:racker/mgcp-terraform-modules//rs-sd-policy/?ref=master"
+# ** This module is now DEPRECATED and has moved **
 
- watchman_token = "00000000000"
- enabled = true
- project_id = "someproject"
-
-rhel_disk_usage {
-    enabled = true
-    blk_dev_name = "sda1"
-    disk_threshold_bytes = 10737418240
-}
-
-debian_disk_usage {
-    enabled = true
-    blk_dev_name = "root"
-    disk_threshold_bytes = 10737418240
-}
-
-windows_disk_usage {
-    enabled = true
-    blk_dev_name = "C:"
-    disk_threshold_percentage = 90
-}
-
-memory_usage {
-    enabled = true
-    mem_threshold = 100
-}
-
-nat_alert {
-    enabled = false
-}
-
-}
-```
-
-## Providers
-
-| Name | Version |
-|------|---------|
-| google | n/a |
-
-## Inputs
-
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
-| debian\_disk\_usage | Memory Usage Parameters | <pre>object({<br>    enabled              = bool<br>    blk_dev_name         = string<br>    disk_threshold_bytes = number<br>  })<br></pre> | <pre>{<br>  "blk_dev_name": "null",<br>  "disk_threshold_bytes": 0,<br>  "enabled": false<br>}<br></pre> | no |
-| enabled | n/a | `bool` | `false` | no |
-| memory\_usage | Memory Usage Parameters | <pre>object({<br>    enabled       = bool<br>    mem_threshold = number<br>  })<br></pre> | <pre>{<br>  "enabled": false,<br>  "mem_threshold": 100<br>}<br></pre> | no |
-| nat\_alert | Memory Usage Parameters | `map` | <pre>{<br>  "enabled": false<br>}<br></pre> | no |
-| project\_id | n/a | `string` | n/a | yes |
-| rhel\_disk\_usage | Memory Usage Parameters | <pre>object({<br>    enabled              = bool<br>    blk_dev_name         = string<br>    disk_threshold_bytes = number<br>  })<br></pre> | <pre>{<br>  "blk_dev_name": "null",<br>  "disk_threshold_bytes": 0,<br>  "enabled": false<br>}<br></pre> | no |
-| uptime\_check | Memory Usage Parameters | `map` | n/a | yes |
-| watchman\_token | n/a | `string` | n/a | yes |
-| windows\_disk\_usage | Memory Usage Parameters | <pre>object({<br>    enabled                   = bool<br>    blk_dev_name              = string<br>    disk_threshold_percentage = number<br>  })<br></pre> | <pre>{<br>  "blk_dev_name": "null",<br>  "disk_threshold_percentage": 80,<br>  "enabled": false<br>}<br></pre> | no |
-
-## Outputs
-
-No output.
+New location: https://github.com/global-build/terraform-google-rs_monitoring_policy


### PR DESCRIPTION
This is a PR just to update README's to new locations going forward

However, the new location is not public at the moment so will fail when circle ci tries to test code.

The existing modules need to stay as the few terraform customers we have are using them still

A decision on how we handle the new module location regarding private vs public needs to be made. If private then Cicle CI will need access given to the module location https://github.com/global-build